### PR TITLE
Convert poc8003636/poc1 to GitHub Actions

### DIFF
--- a/.github/workflows/poc1.yml
+++ b/.github/workflows/poc1.yml
@@ -1,0 +1,48 @@
+name: poc8003636/poc1
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  AWS_ACCESS_KEY_ID: AKIAU3CPNR4AHNXTMASR
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: "$TF_STATE_NAME"
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - uses: actions/download-artifact@v4.1.0
+      with:
+        name: build


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/poc8003636/poc1) :tada:

## Manual steps

Perform the following steps to complete the migration:

### poc8003636/poc1
- [ ] Ensure an environment with the name '`$TF_STATE_NAME`' exists by following these [instructions](https://docs.github.com/en/actions/reference/environments#required-reviewers).
- [ ] Ensure secret is available: `${{ secrets.AWS_SECRET_ACCESS_KEY }}`